### PR TITLE
Fix event unsubscriptions and controller cleanup

### DIFF
--- a/Claw Game/Assets/Scripts/MVCs/Game MVC/GameController.cs
+++ b/Claw Game/Assets/Scripts/MVCs/Game MVC/GameController.cs
@@ -99,12 +99,12 @@ namespace Minigame.Presentation
 
         private void DeInitializeScoreBoardMVC()
         {
-            _cpController.DeInit();
+            _spController.DeInit();
         }
 
         private void DeInitializeControllerPanelMVC()
         {
-            _spController.DeInit();
+            _cpController.DeInit();
         }
         
         #endregion
@@ -151,8 +151,8 @@ namespace Minigame.Presentation
         }
         private void RemoveEvents()
         {
-            OnVerticalClawMovementCompleteEvent -= _gpController.OnVerticalClawMovementComplete; 
-            _spController.OnClawVerticalMovementCompleteEvent -= OnVerticalClawMovementComplete;
+            OnVerticalClawMovementCompleteEvent -= _spController.OnVerticalClawMovementComplete;
+            _gpController.OnVerticalClawMovementCompleteEvent -= OnVerticalClawMovementComplete;
             OnStickMovedEvent -= _gpController.OnStickMoved;
             _cpController.OnStickMovedEvent -= OnStickMoved;
             OnGameButtonClickedEvent -= _gpController.OnGameButtonClick;

--- a/Claw Game/Assets/Scripts/MVCs/Gameplay MVC/GameplayController.cs
+++ b/Claw Game/Assets/Scripts/MVCs/Gameplay MVC/GameplayController.cs
@@ -95,10 +95,10 @@ namespace Minigame.Presentation
     
         private void RemoveEvents()
         {
-            _clawController.OnVerticalClawMovementCompleteEvent += OnVerticalClawMovementComplete;
-            OnVerticalClawMovementCompleteEvent += View.OnVerticalClawMovementComplete;
-            OnGameButtonClickedEvent += _clawController.OnGameButtonClick;
-            OnStickMovedEvent += _clawController.OnStickMoved;
+            _clawController.OnVerticalClawMovementCompleteEvent -= OnVerticalClawMovementComplete;
+            OnVerticalClawMovementCompleteEvent -= View.OnVerticalClawMovementComplete;
+            OnGameButtonClickedEvent -= _clawController.OnGameButtonClick;
+            OnStickMovedEvent -= _clawController.OnStickMoved;
         }
         
         #endregion


### PR DESCRIPTION
## Summary
- Correct controller de-initialization order in GameController
- Properly unsubscribe event handlers in GameController and GameplayController

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a615d46888832289e7e71573c8397b